### PR TITLE
no .db, but use getDb() everywhere

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-simple-auth-pouch",
-  "version": "0.1.0-beta.6",
+  "version": "0.1.0-beta.7",
   "description": "Ember Simple Auth Authenticator for Pouch.",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
This will make it possible to switch databases before logging in.